### PR TITLE
fix: oom when third response too long

### DIFF
--- a/base/basethird/http.go
+++ b/base/basethird/http.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const defaultMaxLoggedBodyLength int64 = 1000 * 1000 // 1MB
+const defaultMaxLoggedRespMsgSizeKB int64 = 1024 // 1MB
 
 type PostFile string
 
@@ -91,7 +91,7 @@ type HttpThird struct {
 	password                  string
 	tlsCfg                    *tls.Config
 	logInfoOff                bool
-	maxLoggedBodyLength       int64
+	maxLoggedRespMsgSizeKB    int64
 	once                      sync.Once
 	maxIdleConnsPerHost       int
 	maxConnsPerHost           int
@@ -111,7 +111,10 @@ func (a *HttpThird) InitConfig(configSection string) error {
 	a.ConnectTimeout = yago.Config.GetInt(configSection + ".conn_timeout")
 	a.SslOn = yago.Config.GetBool(configSection + ".ssl_on")
 	a.CertFile = yago.Config.GetString(configSection + ".cert_file")
-	a.maxLoggedBodyLength = defaultMaxLoggedBodyLength
+	a.maxLoggedRespMsgSizeKB = yago.Config.GetInt64(configSection + ".max_logged_resp_size_kb")
+	if a.maxLoggedRespMsgSizeKB <= 0 {
+		a.maxLoggedRespMsgSizeKB = defaultMaxLoggedRespMsgSizeKB
+	}
 	if a.SslOn {
 		if a.CertFile == "" {
 			return fmt.Errorf("cert file is required in config section %s", configSection)
@@ -257,15 +260,12 @@ func (a *HttpThird) SetTLSInsecure() {
 	}
 }
 
-// 设置是否要关闭 info 日志，maxBodyLength可选参数用来设置允许打印的最大的response body的长度，单位Byte
-func (a *HttpThird) SetLogInfoFlag(on bool, maxLoggedBodyLengthOpt ...int64) {
+// 设置是否要关闭 info 日志
+func (a *HttpThird) SetLogInfoFlag(on bool) {
 	if on {
 		a.logInfoOff = false
 	} else {
 		a.logInfoOff = true
-	}
-	if len(maxLoggedBodyLengthOpt) != 0 && maxLoggedBodyLengthOpt[0] > 0  {
-		a.maxLoggedBodyLength = maxLoggedBodyLengthOpt[0]
 	}
 }
 
@@ -510,7 +510,7 @@ func (a *HttpThird) logInterceptor(method, uri string, ro *grequests.RequestOpti
 	logInfo["status_code"] = resp.StatusCode
 
 	retStr :=  fmt.Sprintf("response body is too long to show, content length %d", resp.RawResponse.ContentLength)
-	if resp.RawResponse.ContentLength < a.maxLoggedBodyLength {
+	if resp.RawResponse.ContentLength < a.maxLoggedRespMsgSizeKB * 1024 {
 		retStr, _ = resp.String()
 	}
 

--- a/example/conf/app.toml
+++ b/example/conf/app.toml
@@ -148,6 +148,7 @@ hostname = "localhost"
 timeout = 10
 # ssl_on = true
 # cert_file = "./conf/server.pem"
+# max_logged_resp_size_kb = 10
 
 [home_rpc_api]
 address = "127.0.0.1:50051"


### PR DESCRIPTION
在third Ins初始化的时候可以用SetLogInfoFlag配置可打印的最大body的大小